### PR TITLE
Don't edit CKEditor files for git tags

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,10 @@
 ---
 
+clone:
+  git:
+    image: plugins/git
+    tags: true
+
 pipeline:
   restore-cache:
     image: drillster/drone-volume-cache

--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -61,20 +61,14 @@ VERSION="4.6.0 DEV"
 REVISION=$(git rev-parse --verify --short HEAD)
 SEMVER_REGEX="^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9A-Za-z-]+)?(\.?[0-9A-Za-z-]+)?$"
 
-if [ -z "${DRONE_TAG}" ];
+# Get version number from tag (if available and follows semantic versioning principles).
+# Use 2>/dev/null to block "fatal: no tag exactly matches", true is needed because of "set -e".
+TAG=$(git describe --tags --exact-match 2>/dev/null) || true
+# "Git Bash" does not support regular expressions.
+if echo $TAG | grep -E "$SEMVER_REGEX" > /dev/null
 then
-	# Get version number from tag (if available and follows semantic versioning principles).
-	# Use 2>/dev/null to block "fatal: no tag exactly matches", true is needed because of "set -e".
-	TAG=$(git describe --tags --exact-match 2>/dev/null) || true
-	# "Git Bash" does not support regular expressions.
-	if echo $TAG | grep -E "$SEMVER_REGEX" > /dev/null
-	then
-		echo "Setting version to $TAG"
-		VERSION=$TAG
-	fi
-else
-	echo "Setting version from DRONE_TAG to ${DRONE_TAG}"
-	VERSION=${DRONE_TAG}
+	echo "Setting version to $TAG"
+	VERSION=$TAG
 fi
 
 java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ../../ release $JAVA_ARGS --version="$VERSION" --revision="$REVISION" --overwrite --no-zip --no-tar


### PR DESCRIPTION
#### chore(build): Revert modifications of CKEditor build script

This reverts commit 4348764 "Use DRONE_TAG environment variable as build
version": when possible, it's better not to change source project files
(so it's easier to rebase on next upstream versions).
See next commit for a more generic solution.

PS: This commit 4348764 should have been a `chore`, again see
http://karma-runner.github.io/3.0/dev/git-commit-msg.html:

> feat: new feature for the user, **not a new feature for build script**

---

#### chore(build): Fetch tags from source Git repository

Tag names are used by the build script.

We use the same trick in `.drone.yml` in our other repos.

---

PR note: tested with a real tag: https://ci.tolteck.com/tolteck/ckeditor-dev/56.