### PR TITLE
chore(build): Partially revert command to install needed packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
   tests:
     image: openjdk
     commands:
-      - yum -y install git wget
+      - yum -y install git
       - dev/builder/build.sh
 
   github_release:


### PR DESCRIPTION
A previous proof-of-concept commit (235f793) installed `git` and `wget`,
but `wget` is not needed actually (I've made the test to confirm it).
So let's save some time and bytes.

---

PR note: tested on a fake git tag: https://ci.tolteck.com/tolteck/ckeditor-dev/57.