### PR TITLE
Add 'de', 'it' and 'pt' locales

### DIFF
--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -91,6 +91,7 @@ var CKBUILDER_CONFIG = {
 		wysiwygarea: 1
 	},
 	languages : {
+		'de': 1,
 		'en': 1,
 		'es': 1,
 		'fr': 1,

--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -96,5 +96,6 @@ var CKBUILDER_CONFIG = {
 		'es': 1,
 		'fr': 1,
 		'it': 1,
+		'pt': 1,
 	}
 };

--- a/dev/builder/build-config.js
+++ b/dev/builder/build-config.js
@@ -95,5 +95,6 @@ var CKBUILDER_CONFIG = {
 		'en': 1,
 		'es': 1,
 		'fr': 1,
+		'it': 1,
 	}
 };


### PR DESCRIPTION

#### feat(build): Add 'de' locale to build

---

#### feat(build): Add 'it' locale to build

---

#### feat(build): Add 'pt' locale to build

---

PR note: according to the build outputs I've made, the difference in build size goes from:

```
Release process completed:

    Number of files: 569
    Total size.....: 4123169 bytes
    Time taken.....: 38.661seconds
```
to:

```
Release process completed:

    Number of files: 614
    Total size.....: 4195825 bytes
    Time taken.....: 38.738seconds
```

so +70 kB, but this should not impact software importing CKEditor, as long as they don't `import 'ckeditor/lang/xx'`.