### PR TITLE
chore(build): Be explicit on OpenJDK image to use

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ pipeline:
       - /tmp/cache:/cache
 
   tests:
-    image: openjdk
+    image: openjdk:12
     commands:
       - yum -y install git
       - dev/builder/build.sh


### PR DESCRIPTION
Because now, Docker image `openjdk` doesn't have `yum` (nor `dnf` nor
`apt-get` nor `apk`) and fails to install Git. Using `openjdk:12` works.