### PR TITLE
chore(build): Fix build script on DEV (when no tag)

### DIFF
--- a/dev/builder/build.sh
+++ b/dev/builder/build.sh
@@ -105,7 +105,7 @@ EOM
 
 echo ""
 echo "Creating ckeditor_$VERSION.tar.gz..."
-cd release; tar -czf ckeditor_$VERSION.tar.gz ckeditor; cd ..
+cd release; tar -czf "ckeditor_$VERSION.tar.gz" ckeditor; cd ..
 
 # Copy and build tests.
 if [[ "$ARGS" == *\ \-t\ * ]]; then


### PR DESCRIPTION
This fixes code from commit 77350d2 "Create a package.json file", in the
case when there is no Git tag on current commit. In such a case, the
package name contains a space character ('ckeditor_4.6.0 DEV.tar.gz'),
so it must be quoted. Otherwise:

    Creating ckeditor_4.6.0 DEV.tar.gz...
    tar: DEV.tar.gz: Cannot stat: No such file or directory