### PR TITLE
feat(moono-lisa): Remove CSS hack for old IE (7 and below)

### DIFF
--- a/skins/moono-lisa/dialog.css
+++ b/skins/moono-lisa/dialog.css
@@ -515,7 +515,6 @@ textarea.cke_dialog_ui_input_textarea
 	padding: 4px 6px;
 	outline: none;
 	width: 100%;
-	*width: 95%;
 
 	box-sizing: border-box;
 
@@ -592,8 +591,6 @@ The buttons used in the dialog footer or inside the contents.
 a.cke_dialog_ui_button
 {
 	display: inline-block;
-	*display: inline;
-	*zoom: 1;
 
 	padding: 4px 1px;
 	margin: 0;


### PR DESCRIPTION
These CSS hacks are intended for old browsers, and aren't so useful
now, I think: https://stackoverflow.com/a/6711941

Removing them will avoid build warnings on Angular 12.2+:
```
assets/ck/skins/moono-lisa/dialog.css - Warning: Css Minimizer Plugin:
assets/ck/skins/moono-lisa/dialog.css:5:4726: warning:
Expected identifier but found "*"
    5 │ ...ing:4px 6px;outline:0;width:100%;*width:95%;...
      ╵                                     ^
assets/ck/skins/moono-lisa/dialog.css - Warning: Css Minimizer Plugin:
assets/ck/skins/moono-lisa/dialog.css:5:5748: warning:
Expected identifier but found "*"
    5 │ ...g_ui_button{display:inline-block;*display:inline;...
      ╵                                     ^
assets/ck/skins/moono-lisa/dialog.css - Warning: Css Minimizer Plugin:
assets/ck/skins/moono-lisa/dialog.css:5:5764: warning:
Expected identifier but found "*"
    5 │ ...lay:inline-block;*display:inline;*zoom:1;...
      ╵                                     ^
```