### PR TITLE
fix(range): Don't assume 'this' refers to the window object

### DIFF
--- a/core/dom/range.js
+++ b/core/dom/range.js
@@ -2913,7 +2913,7 @@ CKEDITOR.dom.range = function( root ) {
 		 * @returns {CKEDITOR.dom.rect[]}
 		 */
 		getClientRects: ( function() {
-			if ( this.document.getSelection !== undefined ) {
+			if ( document.getSelection !== undefined ) {
 				return function( isAbsolute ) {
 					// We need to create native range so we can call native getClientRects.
 					var range = this.root.getDocument().$.createRange(),


### PR DESCRIPTION
The following error happen if CKEditor is injected in a page as a
`type="module"` script:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'document')
```

In regular scripts, `this` refers to the `window` object while it is
`undefined` in ES6 modules.
That's what is causing this error.

Since CKE was created before ES6 modules, it is using `this.document`
with the assumption that `this === window`.

It's easy to reproduce:
- regular script:
  ```html
  <html>
    <body>
      <script defer src="app.js"></script>
    </body>
  </html>
  ```
  ```js
  // app.js
  console.log(this);  // ← window object
  ```
- ES6 module:
  ```html
  <html>
    <body>
      <script type="module" src="app.js"></script>
    </body>
  </html>
  ```
  ```js
  // app.js
  console.log(this);  // ← undefined
  ```
  
A way to fix this issue is using [shimming] with Webpack's
`imports-loader`. Its job is to wrap `app.js` code in an IIFE passing
the `window` object to it like this:
```js
// app.js
(function() {
    console.log(this);  // ← window object
}.call(window));
```

But unfortunately this doesn't work for CKE because this part of the
code is already inside an IIFE and the `window` object still won't be
available on CKE scope:
```js
// ckeditor.js wrapped with `imports-loader`
(function() {                   // ← imports-loader code
    console.log(this);          // ← window object
    (function() {               // ← CKE code
        // CKE code accessing this.document.…
        console.log(this);      // ← still undefined
    })();                       // ← CKE code
}.call(window));                // ← imports-loader code
```

After many searches accross CKE code base, it looks like the place this
commit changes is the only one where:
- we're in an IIFE so the code is executed immediately
- it uses `this.document` to access native `document` element (CKE also
declares a [`document`] object that is accessed with `this.document`)

At other places, where it accesses the native `document` object,
it simply call it directly, not via `this.document`.
That's what this commit do.

[shimming]: https://webpack.js.org/guides/shimming/#granular-shimming
[`document`]: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_document.html
