### PR TITLE
fix(clipboard): Prevent a crash on drag & drop in the same editor

### DIFF
--- a/plugins/clipboard/plugin.js
+++ b/plugins/clipboard/plugin.js
@@ -1545,7 +1545,7 @@
 					dragRange = clipboard.dragRange;
 
 				// Do nothing if it was not possible to get drop range.
-				if ( !dropRange ) {
+				if ( !dropRange || !dragRange ) {
 					return;
 				}
 


### PR DESCRIPTION
This commit attempts to fix this long standing issue we have with CKEditor4:
```
Cannot read properties of undefined (reading 'endContainer')
```
https://sentry.tolteck.com/sentry/quetzal-prod/?query=endContainer

I wasn't able to reproduce the error myself after many many attempts. I don't understand how users are generating it even if the place in the code that is failing is obvious.

So let's impeach this to happen by avoiding undefined `dragRange` to propagate.

Note: I propose to patch the code early in the call chain of functions and events that finish inside function `isDropRangeAffectedByDragRange` because we know it will produce an error anyway.