### PR TITLE
config: Always allow providing additional entities

### DIFF
--- a/plugins/entities/plugin.js
+++ b/plugins/entities/plugin.js
@@ -129,10 +129,10 @@
 
 					if ( config.entities_greek )
 						selectedEntities.push( greek );
-
-					if ( config.entities_additional )
-						selectedEntities.push( config.entities_additional );
 				}
+
+				if ( config.entities_additional )
+					selectedEntities.push( config.entities_additional );
 
 				var entitiesTable = buildTable( selectedEntities.join( ',' ) );
 
@@ -236,7 +236,7 @@ CKEDITOR.config.entities_greek = true;
  *
  *		config.entities_additional = '#1049'; // Adds Cyrillic capital letter Short I (Й).
  *
- * @cfg {String} [entities_additional='#39' (The single quote (') character)]
+ * @cfg {String} [entities_additional='']
  * @member CKEDITOR.config
  */
-CKEDITOR.config.entities_additional = '#39';
+CKEDITOR.config.entities_additional = '';


### PR DESCRIPTION
Before this commit, `additional_entities` wasn't taken into account if
`entities` was false.
Setting `entities` to true would encode too many chars (for example, it
would turn `é` into `&eacute;`), so let's change this in order to have an
easy way of adding extra characters to encode in HTML, without having to
set `entities` to true.

This commit doesn't have any impact, as long as CKEditor instance
config isn't changed to provide `additional_entities`.