### PR TITLE
CI: Adapt release process for immutable releases

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -1,38 +1,52 @@
 ---
 
-clone:
-  git:
-    image: plugins/git
-    tags: true
+kind: pipeline
+type: docker
 
-pipeline:
-  restore-cache:
+steps:
+  - name: fetch git tags
+    image: alpine/git
+    commands:
+      - git fetch --tags
+
+  - name: restore cache
     image: drillster/drone-volume-cache
-    restore: true
-    mount:
-      - dev/builder/ckbuilder
     volumes:  # mount the cache volume, needs "Trusted"
-      - /tmp/cache:/cache
+      - name: cache
+        path: /cache
+    settings:
+      restore: true
+      mount:
+        - dev/builder/ckbuilder
 
-  tests:
+  - name: tests
     image: openjdk:12
     commands:
       - yum -y install git
       - dev/builder/build.sh
 
-  github_release:
+  - name: github release
     image: plugins/github-release
-    files: dev/builder/release/ckeditor_${DRONE_TAG}.tar.gz
-    secrets: [github_token]
-    checksum:
-      - sha256
+    settings:
+      files: dev/builder/release/ckeditor_${DRONE_TAG}.tar.gz
+      checksum:
+        - sha256
+      api_key:
+        from_secret: github_token
     when:
       event: tag
 
-  rebuild-cache:
+  - name: rebuild cache
     image: drillster/drone-volume-cache
-    rebuild: true
-    mount:
-      - dev/builder/ckbuilder
     volumes:  # mount the cache volume, needs "Trusted"
-      - /tmp/cache:/cache
+      - name: cache
+        path: /cache
+    settings:
+      rebuild: true
+      mount:
+        - dev/builder/ckbuilder
+
+volumes:
+  - name: cache
+    host:
+      path: /tmp/cache

--- a/.drone.yaml
+++ b/.drone.yaml
@@ -25,12 +25,21 @@ steps:
       - yum -y install git
       - dev/builder/build.sh
 
-  - name: github release
+  - name: create draft release
     image: plugins/github-release
     settings:
+      draft: true
       files: dev/builder/release/ckeditor_${DRONE_TAG}.tar.gz
       checksum:
         - sha256
+      api_key:
+        from_secret: github_token
+    when:
+      event: tag
+
+  - name: publish release
+    image: plugins/github-release
+    settings:
       api_key:
         from_secret: github_token
     when:


### PR DESCRIPTION
### CI: Refactor .drone.yaml to use new drone format

This commit updates the format of `.drone.yaml` to take advantage of the
newer syntax of Drone 1.9.

The main advantage is to make maintenance easier by harmonizing our
drone files across our repositories.

This change is a pure refactoring.

---

### CI: Adapt release process for immutable releases

Github recently released a feature that allows for release to be
immutable (meaning that its asset can't be modified once the release
is created).
This feature is slightly better in terms of security but to make use of
it we need to adapt the release process because the github-release
plugin adds the assets after creating the release and this can't work
with immutable releases.
To make it work, let's instead create the release as draft first, and
then turn the release into a 'real' one in a second step.


---

TODO: 
- [x] test this with a mock release 
