### PR TITLE
CI: Wait for the draft release to be listed

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -37,6 +37,35 @@ steps:
     when:
       event: tag
 
+  # If this step fails while creating a new release, then manually delete the
+  # draft release on Github before relaunching the release job on the CI.
+  - name: wait for draft release
+    image: tolteck/base
+    commands:
+      - |
+          RELEASE_URL="https://api.github.com/repos/tolteck/ckeditor4/releases"
+          DELAY=2
+          for i in 1 2 3; do
+            releases=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \\
+                       "$RELEASE_URL?per_page=10")
+            if echo "$releases" | grep -qF '"tag_name": "'"$DRONE_TAG"'"'; then
+              exit 0
+            fi
+            echo "Release for tag ${DRONE_TAG} still not visible," \\
+                 "waiting $DELAY seconds..."
+            sleep "$DELAY"
+            DELAY=$((DELAY * 2))
+          done
+          echo "Release not found for tag ${DRONE_TAG}, aborting." \\
+               "This can be caused by" \\
+               "https://github.com/tolteck/coatl/pull/1420#discussion_r3458730327"
+          exit 1
+    environment:
+      GITHUB_TOKEN:
+        from_secret: github_token
+    when:
+      event: tag
+
   - name: publish release
     image: plugins/github-release
     settings:


### PR DESCRIPTION
We recently noticed the 2 steps process we have to create immutable releases for CKEditor4 (cf. _CI: Adapt release process for immutable releases_ (5659474)) can fail and end up creating a draft release on Github that contains the assets and another immutable release that doesn't contains the assets (cf. _Coatl version 4.2.7_ (134c452) where it happened first).

This is because the plugin `drone-github-release` calls Github's API route `GET /repos/<repo>/releases?per_page=10` [^1].

It can take some time for this API route to return updated results and if the plugin doesn't find in the second step the draft release that was just created in the first step it creates another release without the assets but immutable.

To avoid that, let's poll the API directly in an in-between step to make sure the last step always succeeds.

In my tests on the CI, the draft release is not visible on the first API call about ~50% of the time (not measured scientifically) which explains all the troubles we had recently when releasing. It looks like something changed on Github's API side.

More infos can be found in Coatl's mirror PR [^2].

[^1]: https://github.com/drone-plugins/drone-github-release/blob/f2907e9/plugin/release.go#L56-L86
[^2]: https://github.com/tolteck/coatl/pull/1420